### PR TITLE
Update ADI Chain Mainnet addresses for version 1.3.0 and 1.4.1

### DIFF
--- a/safe_eth/safe/addresses.py
+++ b/safe_eth/safe/addresses.py
@@ -3565,8 +3565,12 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x29fcB43b46531BcA003ddC8FCB67FFE91900C762", 3635822, "1.4.1+L2"),  # v1.4.1+L2
     ],
     EthereumNetwork.ADI_CHAIN: [
+        ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 1052, "1.3.0"),  # v1.3.0
+        ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 1051, "1.3.0+L2"),  # v1.3.0+L2
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 972, "1.3.0"),  # v1.3.0
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 971, "1.3.0+L2"),  # v1.3.0+L2
+        ("0x41675C099F32341bf84BFc5382aF534df5C7461a", 1032, "1.4.1"),  # v1.4.1
+        ("0x29fcB43b46531BcA003ddC8FCB67FFE91900C762", 1039, "1.4.1+L2"),  # v1.4.1+L2
     ],
     # This should be EthereumNetwork.ADI_CHAIN_TESTNET, but there's a collision with the chain_id = 99999 already registered
     EthereumNetwork.UB_SMART_CHAIN: [
@@ -5070,7 +5074,9 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
         ("0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67", 3635795),  # v1.4.1
     ],
     EthereumNetwork.ADI_CHAIN: [
+        ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 1044),  # v1.3.0
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 963),  # v1.3.0
+        ("0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67", 1024),  # v1.4.1
     ],
     # This should be EthereumNetwork.ADI_CHAIN_TESTNET, but there's a collision with the chain_id = 99999 already registered
     EthereumNetwork.UB_SMART_CHAIN: [


### PR DESCRIPTION
Adding new deployments based on Safe Singleton Factory for the ADI Chain Mainnet